### PR TITLE
Fixes issue when performing sanity checks

### DIFF
--- a/monotonic.py
+++ b/monotonic.py
@@ -113,7 +113,7 @@ except AttributeError:
                 return ts.tv_sec + ts.tv_nsec / 1.0e9
 
         # Perform a sanity-check.
-        if monotonic() - monotonic() >= 0:
+        if monotonic() - monotonic() > 0:
             raise ValueError('monotonic() is not monotonic!')
 
     except Exception:


### PR DESCRIPTION
The sanity check fails as monotonic() - monotonic() can return 0.0.
This is a blocking issue that has been observed on Windows.

Closes issue: #2
