### PR TITLE
Set CLOCK_MONOTONIC for Solaris

### DIFF
--- a/monotonic.py
+++ b/monotonic.py
@@ -118,6 +118,8 @@ except AttributeError:
                     CLOCK_MONOTONIC = 1
             elif sys.platform.startswith('freebsd'):
                 CLOCK_MONOTONIC = 4
+            elif sys.platform.startswith('sunos5'):
+                CLOCK_MONOTONIC = 4
             elif 'bsd' in sys.platform:
                 CLOCK_MONOTONIC = 3
 


### PR DESCRIPTION
Hi,

A colleague came across a "no suitable implementation" error when another module tried to import monotonic after a pip install on Solaris.

Looking at the Solaris include files it seems as though CLOCK_MONOTONIC should be 4. This change adds this information for the Solaris platform.

Cheers,
~Al

Setting CLOCK_MONOTONIC = 4 as defined in the Solaris time_impl.h
header file.

$ uname -a
SunOS smet52f 5.11 11.2 sun4v sparc sun4v
$ python -c "import sys; print sys.platform"
sunos5
$ grep MONOTONIC /usr/include/sys/time_impl.h
# define CLOCK_MONOTONIC         4       /\* high resolution monotonic

clock */
# define CLOCK_HIGHRES           CLOCK_MONOTONIC         /\* alternate

name */
