### PR TITLE
Add support for cygwin

### DIFF
--- a/monotonic.py
+++ b/monotonic.py
@@ -96,6 +96,16 @@ except AttributeError:
                 """Monotonic clock, cannot go backward."""
                 return GetTickCount64() / 1000.0
 
+        elif sys.platform.startswith('cygwin'):
+            # Cygwin
+            kernel32 = ctypes.cdll.LoadLibrary('kernel32.dll')
+            GetTickCount64 = kernel32.GetTickCount64
+            GetTickCount64.restype = ctypes.c_ulonglong
+
+            def monotonic():
+                """Monotonic clock, cannot go backward."""
+                return GetTickCount64() / 1000.0
+
         else:
             try:
                 clock_gettime = ctypes.CDLL(ctypes.util.find_library('c'),


### PR DESCRIPTION
monotonic on cygwin currently gives a runtime error, and this breaks all of the OpenStack client tools as they now depend on oslo, which is using monotonic:

$ nova
Traceback (most recent call last):
File "/usr/bin/nova", line 7, in 
from novaclient.shell import main
File "/usr/lib/python2.7/site-packages/novaclient/shell.py", line 27, in 
from keystoneclient.auth.identity.generic import password
File "/usr/lib/python2.7/site-packages/keystoneclient/auth/identity/init.py", line 14, in 
from keystoneclient.auth.identity import generic
File "/usr/lib/python2.7/site-packages/keystoneclient/auth/identity/generic/init.py", line 14, in 
from keystoneclient.auth.identity.generic.password import Password # noqa
File "/usr/lib/python2.7/site-packages/keystoneclient/auth/identity/generic/password.py", line 19, in 
from keystoneclient.auth.identity import v2
File "/usr/lib/python2.7/site-packages/keystoneclient/auth/identity/v2.py", line 19, in 
from keystoneclient import access
File "/usr/lib/python2.7/site-packages/keystoneclient/access.py", line 20, in 
from oslo_utils import timeutils
File "/usr/lib/python2.7/site-packages/oslo_utils/timeutils.py", line 26, in 
from monotonic import monotonic as now # noqa
File "/usr/lib/python2.7/site-packages/monotonic.py", line 146, in 
raise RuntimeError('no suitable implementation for this system')
RuntimeError: no suitable implementation for this system

$ keystone
Traceback (most recent call last):
File "/usr/bin/keystone", line 7, in 
from keystoneclient.shell import main
File "/usr/lib/python2.7/site-packages/keystoneclient/shell.py", line 31, in 
from keystoneclient import access
File "/usr/lib/python2.7/site-packages/keystoneclient/access.py", line 20, in 
from oslo_utils import timeutils
File "/usr/lib/python2.7/site-packages/oslo_utils/timeutils.py", line 26, in 
from monotonic import monotonic as now # noqa
File "/usr/lib/python2.7/site-packages/monotonic.py", line 146, in 
raise RuntimeError('no suitable implementation for this system')
RuntimeError: no suitable implementation for this system

The following patch adds support for cygwin.

Cygwin's python does not yet have ctypes.windll support so we fall back to using cdll.LoadLibrary.
