### PR TITLE
clock_gettime() is not thread-safe

### DIFF
--- a/monotonic.py
+++ b/monotonic.py
@@ -119,8 +119,6 @@ except AttributeError:
                 _fields_ = (('tv_sec', ctypes.c_long),
                             ('tv_nsec', ctypes.c_long))
 
-            ts = timespec()
-
             if sys.platform.startswith('linux'):
                 if compare_versions(get_os_release(), '2.6.28') > 0:
                     CLOCK_MONOTONIC = 4  # CLOCK_MONOTONIC_RAW
@@ -135,6 +133,7 @@ except AttributeError:
 
             def monotonic():
                 """Monotonic clock, cannot go backward."""
+                ts = timespec()
                 if clock_gettime(CLOCK_MONOTONIC, ctypes.pointer(ts)):
                     errno = ctypes.get_errno()
                     raise OSError(errno, os.strerror(errno))


### PR DESCRIPTION
Don't use a global variable in clock_gettime(). Create a new timespec
object for each call to clock_gettime().
