### PR TITLE
Don't use CLOCK_MONOTONIC_RAW

### DIFF
--- a/monotonic.py
+++ b/monotonic.py
@@ -122,10 +122,7 @@ except AttributeError:
             ts = timespec()
 
             if sys.platform.startswith('linux'):
-                if compare_versions(get_os_release(), '2.6.28') > 0:
-                    CLOCK_MONOTONIC = 4  # CLOCK_MONOTONIC_RAW
-                else:
-                    CLOCK_MONOTONIC = 1
+                CLOCK_MONOTONIC = 1
             elif sys.platform.startswith('freebsd'):
                 CLOCK_MONOTONIC = 4
             elif sys.platform.startswith('sunos5'):


### PR DESCRIPTION
CLOCK_MONOTONIC_RAW doesn't fit into time.monotonic() requirements:
it doesn't use seconds. CLOCK_MONOTONIC is what uses expect for a
monotonic clock using seconds.

For the longer rationale, see the PEP 418:
https://www.python.org/dev/peps/pep-0418/#clock-monotonic-clock-monotonic-raw-clock-boottime
