### PR TITLE
load_library()'s RuntimeException in Python 2.x isn't being caught where it should.

### DIFF
--- a/monotonic.py
+++ b/monotonic.py
@@ -133,7 +133,7 @@ except AttributeError:
             try:
                 clock_gettime = ctypes.CDLL(ctypes.util.find_library('c'),
                                             use_errno=True).clock_gettime
-            except AttributeError:
+            except Exception:
                 clock_gettime = ctypes.CDLL(ctypes.util.find_library('rt'),
                                             use_errno=True).clock_gettime
 


### PR DESCRIPTION
load_library() raises a RunTimeException if it can't find the library it's trying to load. The exception handler was specifically trying to catch an AttributeError exception. On linux systems that don't have `libc` installed in the path, a RunTimeException is raised and subsequently caught by the top-level exception handler, thus this library never attempts to load `librt`.

In reality, if the line of code that attempts to load `libc` and then check for the existence of `clock_gettime` fails for any reason, you still want to attempt to load `librt`.

https://github.com/atdt/monotonic/issues/23