### PR TITLE
Fix order for converting mach absolute time

### DIFF
--- a/monotonic.py
+++ b/monotonic.py
@@ -68,11 +68,12 @@ except AttributeError:
 
             timebase = mach_timebase_info_data_t()
             libc.mach_timebase_info(ctypes.byref(timebase))
-            ticks_per_second = timebase.numer / timebase.denom * 1.0e9
+            nanoseconds_in_second = 1.0e9
 
             def monotonic():
                 """Monotonic clock, cannot go backward."""
-                return mach_absolute_time() / ticks_per_second
+                nanoseconds = mach_absolute_time() * timebase.numer / timebase.denom
+                return nanoseconds / nanoseconds_in_second
 
         elif sys.platform.startswith('win32') or sys.platform.startswith('cygwin'):
             if sys.platform.startswith('cygwin'):


### PR DESCRIPTION
The numer and denum [1] on regular mac are both 1 and numer and denum on
arm64 are 125 and 3. monotonic.py seem to have the order backwards
for converting mach absolute time to nanoseconds according to [2].

[1] https://opensource.apple.com/source/xnu/xnu-792/osfmk/mach/mach_time.h.auto.html
[2] https://developer.apple.com/documentation/apple_silicon/addressing_architectural_differences_in_your_macos_code